### PR TITLE
Fix: Prevent ZeroDivisionError in k_path interpolation

### DIFF
--- a/utils_openmx/utils.py
+++ b/utils_openmx/utils.py
@@ -358,9 +358,30 @@ class kpoints_generator:
         # Find indices of nodes in interpolated list
         node_index=[0]
         for n in range(1,n_nodes-1):
-            frac=k_node[n]/k_node[-1]
-            node_index.append(int(round(frac*(nk-1))))
-        node_index.append(nk-1)
+            frac = k_node[n] / k_node[-1]
+            new_index = int(round(frac * (nk - 1)))
+            # Ensure the new index is at least 1 greater than the previous one to prevent assigning the same index
+            if new_index <= node_index[-1]:
+                new_index = node_index[-1] + 1
+            node_index.append(new_index) 
+        # Ensure the last index is nk-1 and greater than the previous one
+        if n_nodes > 1:
+            if (nk - 1) <= node_index[-1]:
+                node_index.append(node_index[-1] + 1)
+            else:
+                node_index.append(nk-1)
+        # If too many path points cause indices to exceed the range, perform clipping
+        if node_index[-1] >= nk:
+            print("Warning: Too many k-path nodes for the given nk. Some segments might be very short.")
+            # Correct indices exceeding the range to nk-1
+            node_index = [min(i, nk - 1) for i in node_index]
+            # Ensure strictly increasing again by removing duplicates
+            final_indices = []
+            for i in node_index:
+                if not final_indices or i > final_indices[-1]:
+                    final_indices.append(i)
+            node_index = final_indices
+
     
         # initialize two arrays temporarily with zeros
         #   array giving accumulated k-distance to each k-point


### PR DESCRIPTION
The `k_path` function could fail with a `ZeroDivisionError` when processing a k-path with very short segments. This happened because the calculation for `node_index` would round the position of two different high-symmetry points to the same integer index, resulting in a zero-length segment `(n_f == n_i`) during interpolation.

This commit fixes the issue by ensuring that the calculated `node_index` is always strictly increasing. It checks if a new index is smaller than or equal to the previous one, and if so, increments it by one, guaranteeing each segment receives at least one interpolation point.

Closes #55 