### PR TITLE
fix: handle empty edge difference in compute_graph_difference

### DIFF
--- a/utils_abacus/build_graph_from_coordinates.py
+++ b/utils_abacus/build_graph_from_coordinates.py
@@ -256,8 +256,12 @@ def compute_graph_difference(edge_indices_1, cell_shifts_1, edge_indices_2, cell
     # Compute the difference: edges and shifts in the first graph but not in the second
     difference_edges_with_shifts = edges_with_shifts_1 - edges_with_shifts_2
 
-    # Sort the result to ensure a consistent order
+    # The sorted result may be empty, indicating the H0 graph already covers the reference graph
     sorted_edges_with_shifts = sorted(difference_edges_with_shifts)
+    if not sorted_edges_with_shifts:
+        edge_indices_diff = np.empty((2, 0), dtype=edge_indices_1.dtype)
+        cell_shifts_diff = np.empty((0, 3), dtype=cell_shifts_1.dtype)
+        return edge_indices_diff, cell_shifts_diff
 
     # Separate edges and cell shifts
     edge_indices, cell_shifts = zip(*[(edge[:2], edge[2]) for edge in sorted_edges_with_shifts])


### PR DESCRIPTION
## Issue

During graph data generation in `graph_data_gen_abacus.py`, when the H0 graph fully covers the reference graph (i.e., `graph_ref ⊆ graph_h0`), the edge set difference becomes empty. This causes a `ValueError: not enough values to unpack` at line 263 in `build_graph_from_coordinates.py`.

**Call chain:**
```
graph_data_gen_abacus.py:229 (main processing loop)
  → expand_graph() at line 259
    → compute_graph_difference() at build_graph_from_coordinates.py:250
      → zip(*[]) at line 263 [CRASH HERE]
```

**When this occurs:**

The reference graph is constructed purely geometrically using covalent radii scaled by `RADIUS_SCALE_FACTOR`. The H0 graph, however, is based on actual orbital interactions from ABACUS, with edges determined by:

1. **Spatial cutoff**: Orbital cutoff radius `rcut = Phi[T1].getRcut() + Phi[T2].getRcut()`
   - Implemented in [ABACUS source (v3.5.3)](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp#L99-L170)
   - Determines which atom pairs are neighbors based on orbital range

2. **Numerical threshold**: `sparse_threshold` filters out Hamiltonian matrix elements with `|H(R)| ≤ threshold`
   - Implemented in [ABACUS source (v3.5.3)](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp#L201-L287)
   - Determines which matrix elements are retained in the output

When the H0 graph's effective interaction range (determined by `rcut` and `sparse_threshold`) equals or exceeds the reference graph's geometric cutoff (determined by `RADIUS_SCALE_FACTOR × covalent_radii`), complete coverage occurs and the edge difference becomes empty.

This is **more likely** to happen when:
- Using `RADIUS_SCALE_FACTOR = 1.0` (default)
- The basis set has relatively large orbital cutoff radii (e.g., 7 Bohr for Si/O)
- The interaction decays slowly enough that most matrix elements exceed `sparse_threshold`

However, it can also occur with `RADIUS_SCALE_FACTOR` slightly above 1.0, depending on the specific system and basis set parameters.

**Key ABACUS source code references (v3.5.3):**
- H(R) output main function: [`module_io/write_HS_R.cpp#L9-L55`](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_io/write_HS_R.cpp#L9-L55)
- Spatial neighbor filtering: [`LCAO_hamilt.cpp#L99-L170`](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp#L99-L170), [`#L360-L431`](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp#L360-L431)
- Numerical threshold filtering: [`LCAO_hamilt.cpp#L201-L287`](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp#L201-L287), [`#L716-L904`](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp#L716-L904)
- Output filtering: [`write_HS_sparse.cpp#L29-L121`](https://github.com/abacusmodeling/abacus-develop/blob/42b6ede473fbea9df2a0710c9d73af3d0c38e950/source/module_io/write_HS_sparse.cpp#L29-L121)

## Root Cause

The `compute_graph_difference()` function assumes at least one edge difference exists and directly unpacks the result without checking for empty sets. An empty difference set is a **valid input** indicating complete graph coverage, not an error condition.

## Solution

Add a guard clause in `compute_graph_difference()` to handle empty difference sets. When `sorted_edges_with_shifts` is empty, return correctly shaped empty arrays:
- `edge_indices_diff`: shape `(2, 0)`, preserving input dtype
- `cell_shifts_diff`: shape `(0, 3)`, preserving input dtype

This ensures downstream functions (`find_inverse_edge_index`, `expand_graph`) receive valid inputs and can properly handle the zero-padding case.

## Changes

**File**: `utils_abacus/build_graph_from_coordinates.py`

**Location**: Lines 260-263

**Diff**:
```python
    # The sorted result may be empty, indicating the H0 graph already covers the reference graph
    sorted_edges_with_shifts = sorted(difference_edges_with_shifts)
+   if not sorted_edges_with_shifts:
+       edge_indices_diff = np.empty((2, 0), dtype=edge_indices_1.dtype)
+       cell_shifts_diff = np.empty((0, 3), dtype=cell_shifts_1.dtype)
+       return edge_indices_diff, cell_shifts_diff

    # Separate edges and cell shifts
    edge_indices, cell_shifts = zip(*[(edge[:2], edge[2]) for edge in sorted_edges_with_shifts])
```

## Testing

Verified on crystal structures where H0 graphs (with appropriate `rcut` and `sparse_threshold`) fully cover reference graphs, confirming:
- No `ValueError` exceptions
- Correct zero-edge handling in downstream functions
- Proper zero-padding in expanded tensors