### PR TITLE
Compatibility fixes for current toolchains (PyTorch Lightning 2.x, GCC 13, Python 3.12)

### DIFF
--- a/DFT_interfaces/openmx/openmx_postprocess/Set_ProExpn_VNA.c
+++ b/DFT_interfaces/openmx/openmx_postprocess/Set_ProExpn_VNA.c
@@ -33,7 +33,7 @@ static double Set_VNA3(double *****HVNA3);
 #ifdef kcomp
 static void Spherical_Bessel2( double x, int lmax, double *sb, double *dsb );
 #else 
-inline void Spherical_Bessel2( double x, int lmax, double *sb, double *dsb );
+static inline void Spherical_Bessel2( double x, int lmax, double *sb, double *dsb );
 #endif      
 
 
@@ -2807,7 +2807,7 @@ double Set_VNA3(double *****HVNA3)
 #ifdef kcomp
 static void Spherical_Bessel2( double x, int lmax, double *sb, double *dsb )
 #else 
-inline void Spherical_Bessel2( double x, int lmax, double *sb, double *dsb )
+static inline void Spherical_Bessel2( double x, int lmax, double *sb, double *dsb )
 #endif      
 {
   int m,n,nmax;

--- a/DFT_interfaces/openmx/openmx_postprocess/openmx.c
+++ b/DFT_interfaces/openmx/openmx_postprocess/openmx.c
@@ -1184,7 +1184,7 @@ static inline double ****Allocate4D_double(int size_1, int size_2, int size_3, i
   return buffer;
 }
 
-static void Print_CubeCData_MO(FILE *fp, dcomplex *data, char *op)
+void Print_CubeCData_MO(FILE *fp, dcomplex *data, char *op)
 {
   int i1, i2, i3;
   int GN;
@@ -1235,7 +1235,7 @@ static void Print_CubeCData_MO(FILE *fp, dcomplex *data, char *op)
   }
 }
 
-static void Print_CubeTitle(FILE *fp, int EigenValue_flag, double EigenValue)
+void Print_CubeTitle(FILE *fp, int EigenValue_flag, double EigenValue)
 {
   int ct_AN;
   int spe;

--- a/Uni-HamGNN/Uni-HamiltonianPredictor.py
+++ b/Uni-HamGNN/Uni-HamiltonianPredictor.py
@@ -132,6 +132,9 @@ def _patch_legacy_attributes(predictor) -> None:
                 module.lite_mode = False
             if cls_name == 'PairInteractionBlock' and not hasattr(module, 'legacy_edge_update'):
                 module.legacy_edge_update = True
+            # Older pickled checkpoints (e.g. uni-hamgnn_2_1.pkl on Zenodo) predate this attribute.
+            if cls_name == 'HamGNNConvE3' and not hasattr(module, 'use_gradient_checkpointing'):
+                module.use_gradient_checkpointing = False
 
 
 class HamiltonianPredictor:

--- a/hamgnn/main.py
+++ b/hamgnn/main.py
@@ -15,7 +15,13 @@ import torch.nn as nn
 import numpy as np
 import pytorch_lightning as pl
 from pytorch_lightning.loggers import TensorBoardLogger
-from pytorch_lightning.plugins.training_type import DDPPlugin
+try:
+    from pytorch_lightning.plugins.training_type import DDPPlugin  # PL 1.x
+except ModuleNotFoundError:
+    try:
+        from pytorch_lightning.strategies import DDPStrategy as DDPPlugin  # PL 2.x
+    except ModuleNotFoundError:
+        DDPPlugin = None
 import pprint
 
 from .data.graph_data import graph_data_module


### PR DESCRIPTION
This PR collects four small, independent forward-compatibility fixes that
were needed to run **Uni-HamGNN** inference on a current toolchain:

- Python 3.12
- PyTorch 2.8 + PyG 2.6
- pytorch-lightning **2.6** (instead of the pinned 1.5.10)
- GCC 13 (strict by default; static-after-non-static and C99 inline are
  no longer accepted silently)

Each commit is self-contained and reviewable in isolation:

| # | Commit | File | What it fixes |
|---|---|---|---|
| 1 | `fix(main): support pytorch-lightning 2.x` | `hamgnn/main.py` | `pytorch_lightning.plugins.training_type.DDPPlugin` was removed in PL 2.x. The import sits at module load (`Uni-HamiltonianPredictor.py` imports `hamgnn.main.Model`) so it breaks all PL 2.x users, including inference-only. Falls back to `pytorch_lightning.strategies.DDPStrategy`, then `None`. Inference path doesn't touch DDPPlugin, so the fallback is safe. |
| 2 | `fix(predictor): default use_gradient_checkpointing=False on legacy checkpoints` | `Uni-HamGNN/Uni-HamiltonianPredictor.py` | The Zenodo v2.1 weights (10.5281/zenodo.17239078) were pickled before `HamGNNConvE3` gained `use_gradient_checkpointing`. The first forward pass after unpickling raises `AttributeError`. Extends the existing `_patch_legacy_attributes` helper to default the flag to `False`. |
| 3 | `fix(openmx_postprocess): drop static qualifier mismatched with extern decls` | `DFT_interfaces/openmx/openmx_postprocess/openmx.c` | GCC 12+ rejects `static` definitions that disagree with earlier non-static declarations. `Print_CubeCData_MO` and `Print_CubeTitle` are declared (non-static) earlier in the file and called across translation units, so the `static` was incorrect anyway. |
| 4 | `fix(openmx_postprocess): mark Spherical_Bessel2 as static inline` | `DFT_interfaces/openmx/openmx_postprocess/Set_ProExpn_VNA.c` | Under C99, a plain `inline` function definition produces no out-of-line copy, so current GCC fails to link with `undefined reference to 'Spherical_Bessel2'`. Promoting both the declaration and the definition to `static inline` matches what the `kcomp` branch already gets via `static void` and is binary-compatible. |

### Testing

I ran the full Uni-HamGNN inference pipeline on the ZrSiPt example shipped
in Examples.zip (Zenodo 17239078), comparing the patched code against the
shipped reference Hamiltonian:

- MAE(real) = **5.0e-5**
- MAE(imag) = **1.4e-7**

The predicted band structure is visually indistinguishable from the
authors' reference (`Examples/ZrSiPt/band/pred/band_1.png`) and the
OpenMX-DFT ground truth. End-to-end was also verified from CIF for
silicon (PBE indirect gap ~ 0.66 eV, correct for the Si7.0-s2p2d1 basis)
and ZnO (PBE direct gap ~ 1.12 eV).

### Backward compatibility

- (1) and (2) keep working on PL 1.x and on already-trained checkpoints
  (try/except for the import; `hasattr` guard for the attribute).
- (3) just removes an internal-linkage qualifier that was always
  inconsistent with the declarations.
- (4) adds `static` to `inline`; legal in old C99 and on toolchains where
  the original `inline` did emit a definition.

All four changes are minimal and have no runtime behaviour impact beyond
fixing the load/link errors they target.