### PR TITLE
fix(abacus): parse scientific notation in lattice vectors

### DIFF
--- a/DFT_interfaces/abacus/read_abacus.py
+++ b/DFT_interfaces/abacus/read_abacus.py
@@ -21,6 +21,7 @@ from build_graph_from_coordinates import find_inverse_edge_index
 
 au2ang = 0.5291772490000065
 ry2ha  = 13.60580 / 27.21138506
+float_pattern = re.compile(r'[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?')
 
 def convert_to_int(value):
     """
@@ -269,7 +270,7 @@ class STRU:
                 self.cell = []
                 for j in range(1, 4):
                     if i + j < len(lines):
-                        vec = list(map(float, re.findall(r'[+-]?\d+\.?\d*', lines[i + j])))
+                        vec = list(map(float, float_pattern.findall(lines[i + j])))
                         if len(vec) >= 3:
                             self.cell.append(vec[:3])
                 i += 3


### PR DESCRIPTION
## Summary

- support decimal and scientific-notation values in ABACUS lattice-vector logs
- prevent tiny entries such as `-2.93e-08` from being split into separate numbers
- preserve the existing parsing behavior for ordinary decimal lattice vectors

## Impact

The previous regex could turn near-zero off-diagonal lattice components into order-one values. That corrupted graph cells, neighbor shifts, and downstream Hamiltonian predictions.

## Validation

- parsed representative decimal, integer, and `e`/`E` notation values
- parsed the affected TiO2 `running_scf.log`; recovered cell volume: `3792.344610961793 Bohr^3`
- compared the parsed log structure with the source `STRU`; maximum cell difference: `3.70e-05 Bohr`
- verified an existing non-scientific-notation training log still gives the same `3792.344610961793 Bohr^3` volume
- verified module syntax and import in the `hamgnn-new` environment