### PR TITLE
perf: faster atomic radius lookup and sync-free neighbor counting

### DIFF
--- a/hamgnn/models/base_model.py
+++ b/hamgnn/models/base_model.py
@@ -18,8 +18,8 @@ from easydict import EasyDict
 
 import warnings
 from ase import geometry, neighborlist
+from ase.data import chemical_symbols
 import numpy as np
-from pymatgen.core.periodic_table import Element
 from typing import List, Union
 
 ATOMIC_RADII = {
@@ -81,7 +81,7 @@ def get_radii_from_atomic_numbers(atomic_numbers: Union[torch.Tensor, List[int]]
 
     # Convert atomic numbers to element symbols and then to scaled radii.
     # Use 0.0 as a default value for elements not found in the dictionary.
-    return [radius_scale * ATOMIC_RADII[radius_type].get(Element.from_Z(z).symbol, DEFAULT_RADIUS) for z in atomic_numbers]
+    return [radius_scale * ATOMIC_RADII[radius_type].get(chemical_symbols[int(z)], DEFAULT_RADIUS) for z in atomic_numbers]
 
 
 def neighbor_list_and_relative_vec(

--- a/hamgnn/utils/math_utils.py
+++ b/hamgnn/utils/math_utils.py
@@ -1,11 +1,13 @@
 import torch
 
-def count_neighbors_per_node(source_nodes):
+def count_neighbors_per_node(source_nodes, total_nodes=None):
     """
     Calculate the number of neighbors for each node.
 
     Args:
         source_nodes (torch.Tensor): A tensor containing source node indices.
+        total_nodes (int, optional): Total number of nodes. When provided,
+            avoids GPU-CPU synchronization from querying it from `source_nodes`.
 
     Returns:
         torch.Tensor: A tensor where each index represents a node and the value
@@ -14,8 +16,12 @@ def count_neighbors_per_node(source_nodes):
     # Identify unique nodes and count their occurrences
     unique_nodes, counts = torch.unique(source_nodes, return_counts=True)
 
-    # Determine the total number of nodes
-    total_nodes = source_nodes.max().item() + 1
+    # Determine the total number of nodes. Prefer an explicit size to avoid
+    # GPU-CPU synchronization in hot paths.
+    if total_nodes is None:
+        total_nodes = int(source_nodes.detach().cpu().max()) + 1
+    else:
+        total_nodes = int(total_nodes)
 
     # Initialize a tensor to store the neighbor counts for each node
     neighbor_counts = torch.zeros((total_nodes,)).type_as(source_nodes)


### PR DESCRIPTION
Superseded by PR #112, which includes PR #109's changes plus the fix preserving the scalar-only synchronization path in `count_neighbors_per_node`. PR #112 was merged into `main`.