### PR TITLE
fix: preserve scalar sync in neighbor counting

### DIFF
--- a/hamgnn/models/base_model.py
+++ b/hamgnn/models/base_model.py
@@ -18,8 +18,8 @@ from easydict import EasyDict
 
 import warnings
 from ase import geometry, neighborlist
+from ase.data import chemical_symbols
 import numpy as np
-from pymatgen.core.periodic_table import Element
 from typing import List, Union
 
 ATOMIC_RADII = {
@@ -81,7 +81,7 @@ def get_radii_from_atomic_numbers(atomic_numbers: Union[torch.Tensor, List[int]]
 
     # Convert atomic numbers to element symbols and then to scaled radii.
     # Use 0.0 as a default value for elements not found in the dictionary.
-    return [radius_scale * ATOMIC_RADII[radius_type].get(Element.from_Z(z).symbol, DEFAULT_RADIUS) for z in atomic_numbers]
+    return [radius_scale * ATOMIC_RADII[radius_type].get(chemical_symbols[int(z)], DEFAULT_RADIUS) for z in atomic_numbers]
 
 
 def neighbor_list_and_relative_vec(

--- a/hamgnn/utils/math_utils.py
+++ b/hamgnn/utils/math_utils.py
@@ -1,11 +1,13 @@
 import torch
 
-def count_neighbors_per_node(source_nodes):
+def count_neighbors_per_node(source_nodes, total_nodes=None):
     """
     Calculate the number of neighbors for each node.
 
     Args:
         source_nodes (torch.Tensor): A tensor containing source node indices.
+        total_nodes (int, optional): Total number of nodes. When provided,
+            avoids GPU-CPU synchronization from querying it from `source_nodes`.
 
     Returns:
         torch.Tensor: A tensor where each index represents a node and the value
@@ -14,8 +16,12 @@ def count_neighbors_per_node(source_nodes):
     # Identify unique nodes and count their occurrences
     unique_nodes, counts = torch.unique(source_nodes, return_counts=True)
 
-    # Determine the total number of nodes
-    total_nodes = source_nodes.max().item() + 1
+    # Determine the total number of nodes. Prefer an explicit size to avoid
+    # GPU-CPU synchronization in hot paths.
+    if total_nodes is None:
+        total_nodes = int(source_nodes.detach().cpu().max()) + 1
+    else:
+        total_nodes = int(total_nodes)
 
     # Initialize a tensor to store the neighbor counts for each node
     neighbor_counts = torch.zeros((total_nodes,)).type_as(source_nodes)

--- a/hamgnn/utils/math_utils.py
+++ b/hamgnn/utils/math_utils.py
@@ -16,10 +16,10 @@ def count_neighbors_per_node(source_nodes, total_nodes=None):
     # Identify unique nodes and count their occurrences
     unique_nodes, counts = torch.unique(source_nodes, return_counts=True)
 
-    # Determine the total number of nodes. Prefer an explicit size to avoid
-    # GPU-CPU synchronization in hot paths.
+    # Determine the total number of nodes. Query only the scalar maximum in
+    # the default path; copying the full tensor to CPU would add a transfer.
     if total_nodes is None:
-        total_nodes = int(source_nodes.detach().cpu().max()) + 1
+        total_nodes = source_nodes.max().item() + 1
     else:
         total_nodes = int(total_nodes)
 


### PR DESCRIPTION
This follow-up is based on PR #109 head commit `69c17c32b2945bc582a44b567c23345342a0dba`.

It fixes the remaining performance regression in `count_neighbors_per_node`: the default path now uses `source_nodes.max().item()` instead of copying the full GPU tensor to CPU before computing the maximum. The explicit `total_nodes` path remains available for callers that already know the node count.

Validation:
- `python -m py_compile hamgnn/utils/math_utils.py`
- Default and explicit node-count paths produce identical results.
- Expanded `total_nodes` returns zero counts for absent nodes.
- `git diff --check` passes.

After merging this follow-up, PR #109 can be closed as superseded, or its equivalent change can be applied to the original contributor branch if write access is granted.